### PR TITLE
Actually use the nix provided dependencies and fix the static build that broke as a result of this.

### DIFF
--- a/pkgs/applications/radio/pothos/cstring.patch
+++ b/pkgs/applications/radio/pothos/cstring.patch
@@ -1,0 +1,50 @@
+Submodule blocks contains modified content
+diff --git a/blocks/file/BinaryFileSink.cpp b/blocks/file/BinaryFileSink.cpp
+index 31c9a41..0083b0d 100644
+--- a/blocks/file/BinaryFileSink.cpp
++++ b/blocks/file/BinaryFileSink.cpp
+@@ -13,6 +13,7 @@
+ #endif //_MSC_VER
+ #include <stdio.h>
+ #include <cerrno>
++#include <cstring>
+
+ #ifndef O_BINARY
+ #define O_BINARY 0
+diff --git a/blocks/file/BinaryFileSource.cpp b/blocks/file/BinaryFileSource.cpp
+index 0151231..379d383 100644
+--- a/blocks/file/BinaryFileSource.cpp
++++ b/blocks/file/BinaryFileSource.cpp
+@@ -13,6 +13,7 @@
+ #endif //_MSC_VER
+ #include <stdio.h>
+ #include <cerrno>
++#include <cstring>
+
+ #ifndef O_BINARY
+ #define O_BINARY 0
+diff --git a/blocks/file/TextFileSink.cpp b/blocks/file/TextFileSink.cpp
+index b4b2f08..2be66e2 100644
+--- a/blocks/file/TextFileSink.cpp
++++ b/blocks/file/TextFileSink.cpp
+@@ -6,6 +6,7 @@
+ #include <complex>
+ #include <fstream>
+ #include <cerrno>
++#include <cstring>
+
+ /***********************************************************************
+  * |PothosDoc Text File Sink
+Submodule soapy contains modified content
+diff --git a/soapy/DemoController.cpp b/soapy/DemoController.cpp
+index 4ce8ead..9a4e742 100644
+--- a/soapy/DemoController.cpp
++++ b/soapy/DemoController.cpp
+@@ -6,6 +6,7 @@
+ #include <iostream>
+ #include <chrono>
+ #include <algorithm> //min/max
++#include <cstring>
+
+ /***********************************************************************
+  * |PothosDoc SDR Demo Controller

--- a/pkgs/applications/radio/pothos/default.nix
+++ b/pkgs/applications/radio/pothos/default.nix
@@ -41,7 +41,12 @@ mkDerivation rec {
       url = "https://github.com/pothosware/PothosCore/commit/092d1209b0fd0aa8a1733706c994fa95e66fd017.patch";
       hash = "sha256-bZXG8kD4+1LgDV8viZrJ/DMjg8UvW7b5keJQDXurfkA=";
     })
+    # various source files are missing imports of <cstring>
+    ./cstring.patch
   ];
+
+  # poco 1.14 requires c++17
+  NIX_CFLAGS_COMPILE = [ "-std=gnu++17" ];
 
   nativeBuildInputs = [
     cmake

--- a/pkgs/by-name/po/poco/disable-internal-pcre-files-for-non-static-builds.patch
+++ b/pkgs/by-name/po/poco/disable-internal-pcre-files-for-non-static-builds.patch
@@ -1,0 +1,23 @@
+diff --git a/Foundation/CMakeLists.txt b/Foundation/CMakeLists.txt
+index d5f3b267d..dfaf99a10 100644
+--- a/Foundation/CMakeLists.txt
++++ b/Foundation/CMakeLists.txt
+@@ -31,11 +31,13 @@ if(POCO_UNBUNDLED)
+ 	find_package(ZLIB REQUIRED)
+ 	find_package(Utf8Proc REQUIRED)
+
+-	#HACK: Unicode.cpp requires functions from these files. The can't be taken from the library
+-	POCO_SOURCES(SRCS RegExp
+-		src/pcre2_ucd.c
+-		src/pcre2_tables.c
+-	)
++    if(NOT POCO_STATIC AND BUILD_SHARED_LIBS)
++    	#HACK: Unicode.cpp requires functions from these files. The can't be taken from the library
++    	POCO_SOURCES(SRCS RegExp
++    		src/pcre2_ucd.c
++    		src/pcre2_tables.c
++        )
++    endif()
+
+ else()
+ 	# pcre2

--- a/pkgs/by-name/po/poco/package.nix
+++ b/pkgs/by-name/po/poco/package.nix
@@ -10,6 +10,7 @@
   sqlite,
   openssl,
   unixODBC,
+  utf8proc,
   libmysqlclient,
 }:
 
@@ -32,6 +33,7 @@ stdenv.mkDerivation rec {
 
   buildInputs = [
     unixODBC
+    utf8proc
     libmysqlclient
   ];
   propagatedBuildInputs = [
@@ -50,8 +52,15 @@ stdenv.mkDerivation rec {
   MYSQL_DIR = libmysqlclient;
   MYSQL_INCLUDE_DIR = "${MYSQL_DIR}/include/mysql";
 
-  configureFlags = [
-    "--unbundled"
+  cmakeFlags = [
+    # use nix provided versions of sqlite, zlib, pcre, expat, ... instead of bundled versions
+    "-DPOCO_UNBUNDLED=ON"
+  ];
+
+  patches = [
+    # poco builds its own version of pcre, disable it
+    # https://github.com/pocoproject/poco/issues/4871
+    ./disable-internal-pcre-files-for-non-static-builds.patch
   ];
 
   postFixup = ''


### PR DESCRIPTION
Investigating the build further, I found that the option

```nix
 configureFlags = [
   "--unbundled"
 ];
```

does not actually have any effect, as cmake is used to build this. [It was changed from a cmake flag to a configure flag a while back](https://github.com/NixOS/nixpkgs/commit/369650ef388e4a6488b1783dc747cab7559a90d4), to fix the `nix build .#pkgsStatic.poco` build. That earlier fix seems faulty - not sure it was ever correct.  Reverting that, I found that there was actually a dependency missing, and upstream seems to have [a bug with static builds](https://github.com/pocoproject/poco/issues/4871).